### PR TITLE
Determine the imageTag lazily, using a Provider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,7 @@ gradlePlugin {
     create("dockerPublishPlugin") {
       id = "de.europace.docker-publish"
       displayName = "Docker Publish Plugin"
-      description = "Adds tasks to create and publish a docker image to docker hub"
+      description = "Adds tasks to create and publish a Docker image to a registry"
       implementationClass = "de.europace.gradle.docker.publish.DockerPublishPlugin"
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 # See https://plugins.gradle.org/docs/submit for details.
 gradle.publish.key=
 gradle.publish.secret=
-version="2.0.0-snapshot"
+version=2.0.0-snapshot

--- a/src/main/kotlin/de/europace/gradle/docker/publish/DockerPublishExtension.kt
+++ b/src/main/kotlin/de/europace/gradle/docker/publish/DockerPublishExtension.kt
@@ -16,8 +16,8 @@ abstract class DockerPublishExtension @Inject constructor(project: Project) {
   init {
     artifactTaskName.convention("bootJar")
     artifactName.convention("application.jar")
-    imageName.convention(project.name)
-    imageTag.convention(project.version as String)
+    imageName.convention(project.provider { project.name })
+    imageTag.convention(project.provider { project.version as String })
     dockerBuildContextSources.convention("${project.projectDir.path}/src/main/docker")
   }
 }

--- a/src/test/kotlin/de/europace/gradle/docker/publish/DockerPublishPluginIntegrationTest.kt
+++ b/src/test/kotlin/de/europace/gradle/docker/publish/DockerPublishPluginIntegrationTest.kt
@@ -26,22 +26,22 @@ class DockerPublishPluginIntegrationTest : FreeSpec() {
     "publishImage should have tasks in right order" {
       buildFile.writeText(
           """
-        plugins {
+          plugins {
             id("$PLUGIN_ID")
-        }
-        
-        dockerPublish {
-          organisation.set("foo")
-        }
-        
-        tasks {
-          create("bootJar") {
-            doFirst{
-                 logger.lifecycle("Would now create jar file")
+          }
+          
+          dockerPublish {
+            organisation.set("foo")
+          }
+          
+          tasks {
+            create("bootJar") {
+              doFirst {
+                logger.lifecycle("Would now create jar file")
+              }
             }
           }
-        }
-    """
+          """.trimIndent()
       )
 
       val result = GradleRunner.create()
@@ -51,13 +51,14 @@ class DockerPublishPluginIntegrationTest : FreeSpec() {
           .forwardOutput()
           .build()
 
-      val expectedOutput = """:bootJar SKIPPED
-:copyArtifact SKIPPED
-:prepareBuildContext SKIPPED
-:buildImage SKIPPED
-:publishImage SKIPPED
-:rmiLocalImage SKIPPED
-"""
+      val expectedOutput = """
+        :bootJar SKIPPED
+        :copyArtifact SKIPPED
+        :prepareBuildContext SKIPPED
+        :buildImage SKIPPED
+        :publishImage SKIPPED
+        :rmiLocalImage SKIPPED
+        """.trimIndent()
       result.output shouldStartWith expectedOutput
       result.output shouldContain "BUILD SUCCESSFUL"
     }
@@ -65,18 +66,18 @@ class DockerPublishPluginIntegrationTest : FreeSpec() {
     "publishImage should fail if no organisation is set" {
       buildFile.writeText(
           """
-        plugins {
-            id("$PLUGIN_ID")
-        }
-        
-        tasks {
-          create("bootJar") {
-            doFirst{
-                 logger.lifecycle("Would now create jar file")
+          plugins {
+              id("$PLUGIN_ID")
+          }
+          
+          tasks {
+            create("bootJar") {
+              doFirst{
+                   logger.lifecycle("Would now create jar file")
+              }
             }
           }
-        }
-    """
+          """.trimIndent()
       )
 
       val exception = shouldThrow<UnexpectedBuildFailure> {
@@ -84,12 +85,14 @@ class DockerPublishPluginIntegrationTest : FreeSpec() {
         GradleRunner.create()
             .withProjectDir(testProjectDir)
             .withPluginClasspath()
-            .withArguments("publishImage", "--dry-run")
+            .withArguments("publishImage")
             .forwardOutput()
             .build()
       }
-      val expectedOutput = """> Could not create task ':publishImage'.
-   > organisation must be set"""
+      val expectedOutput = """
+        Execution failed for task ':buildImage'.
+        > organisation must be set
+        """.trimIndent()
 
       exception.message shouldContain expectedOutput
       exception.message shouldContain "BUILD FAILED"
@@ -98,13 +101,14 @@ class DockerPublishPluginIntegrationTest : FreeSpec() {
     "publishImage should fail if no bootJar task is available" {
       buildFile.writeText(
           """
-        plugins {
-            id("$PLUGIN_ID")
-        }
-        
-        dockerPublish {
-          organisation.set("foo")
-        }"""
+          plugins {
+              id("$PLUGIN_ID")
+          }
+          
+          dockerPublish {
+            organisation.set("foo")
+          }
+          """.trimIndent()
       )
 
       val exception = shouldThrow<UnexpectedBuildFailure> {

--- a/src/test/kotlin/de/europace/gradle/docker/publish/DockerPublishPluginTest.kt
+++ b/src/test/kotlin/de/europace/gradle/docker/publish/DockerPublishPluginTest.kt
@@ -110,6 +110,19 @@ class DockerPublishPluginTest : FreeSpec() {
         task.enableBuildLog.get() shouldBe true
       }
 
+      "should evaluate the project version lazily" {
+        val project = createProject().withArtifactTask()
+        project.createDockerPublishExtension()
+
+        project.version = "version-before-evaluate"
+        project.pluginManager.apply(DockerPublishPlugin::class.java)
+        project.evaluate()
+        project.version = "version-after-evaluate"
+
+        val task = (project.tasks.getByName("buildImage") as DockerBuildTask)
+        task.imageName.get() shouldBe "someOrganisation/${project.name}:version-after-evaluate"
+      }
+
       "should set correct defined values" {
         val expectedName = "expectedName"
         val expectedTag = "expectedTag"


### PR DESCRIPTION
When dynamically generating a `project.version`, the evaluation order of plugins decides when the `version` is valid.

Consider a Gradle script like this:

```
plugins {
  id("de.europace.docker-publish")
  id("de.europace.gradle.artifact-version")
}
```

Currently, the `de.europace.docker-publish` plugin uses the project version as default image tag. Yet, the `de.europace.gradle.artifact-version` determines a project version _after_ the docker-publish plugin read the project version, which results in Docker images being tagged with `unspecified` instead of the desired timestamp.

This pull request changes the plugin's behaviour to leverage Gradle's provider mechanism, reading the project version not at configuration time, but at task execution time.

Closes #12