### PR TITLE
Lookup the AuthConfig by repository name

### DIFF
--- a/src/main/kotlin/de/europace/gradle/docker/publish/DockerPublishPlugin.kt
+++ b/src/main/kotlin/de/europace/gradle/docker/publish/DockerPublishPlugin.kt
@@ -58,7 +58,7 @@ class DockerPublishPlugin : Plugin<Project> {
         it.dependsOn(buildImage)
         it.repositoryName.set(dockerImageId(project, extension))
         it.finalizedBy(rmiLocalImage)
-        it.authConfig.set(it.dockerClient.readDefaultAuthConfig())
+        it.authConfig.set(project.provider { it.dockerClient.resolveAuthConfigForImage(dockerImageId(project, extension).get()) })
       }
 
       project.tasks.named(PUBLISH_LIFECYCLE_TASK_NAME) {


### PR DESCRIPTION
The docker push task currently only supports authenticated pushes to the Docker Hub. To allow pushes to other registries, we have to lookup the authentication data depending on the actual image repository.

Requires https://github.com/gesellix/gradle-docker-plugin/releases/tag/v2022-01-29T20-50-00, which has been merged with #80.
Requires #81 to fix the integration tests.

This one _might_ be a major release due to changed behaviour. Yet, the behaviour won't change for existing usages, because the authentication lookup for the default registry (docker.io/Docker Hub) has _not changed_. So, I'd suggest to release this change with a minor version bump as "1.2.0".
