### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin is available on the official [Gradle plugin portal](https://plugins.g
     plugins {
       id("de.europace.docker-publish") version "..."
     }
-    
+
     dockerPublish{
         organisation.set("my-dockerhub-organisation")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,7 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
-}
 val javaVersion = JavaVersion.VERSION_1_8
-val kotestVersion = "4.6.4"
+val kotestVersion = "5.2.2"
 val kotlinVersion = "1.6.21" // remember to update in plugins
-val kotlinxVersion = "1.5.2"
+val kotlinxVersion = "1.6.0"
 val mockkVersion = "1.12.3"
 
 plugins {
@@ -53,7 +47,7 @@ repositories {
 
 dependencies {
   implementation(gradleApi())
-  implementation("de.gesellix:gradle-docker-plugin:2022-02-07T21-51-00")
+  implementation("de.gesellix:gradle-docker-plugin:2022-04-23T15-43-00")
 
   testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
   testImplementation("io.kotest:kotest-framework-engine-jvm:$kotestVersion")

--- a/src/main/kotlin/de/europace/gradle/docker/publish/DockerPublishExtension.kt
+++ b/src/main/kotlin/de/europace/gradle/docker/publish/DockerPublishExtension.kt
@@ -16,7 +16,7 @@ abstract class DockerPublishExtension @Inject constructor(project: Project) {
   init {
     artifactTaskName.convention("bootJar")
     artifactName.convention("application.jar")
-    imageName.convention(project.provider { project.name })
+    imageName.convention(project.provider { project.name.lowercase() })
     imageTag.convention(project.provider { project.version as String })
     dockerBuildContextSources.convention("${project.projectDir.path}/src/main/docker")
   }

--- a/src/test/kotlin/de/europace/gradle/docker/publish/DockerPublishPluginTest.kt
+++ b/src/test/kotlin/de/europace/gradle/docker/publish/DockerPublishPluginTest.kt
@@ -7,7 +7,6 @@ import de.gesellix.gradle.docker.tasks.DockerRmiTask
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.string.shouldEndWith
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal


### PR DESCRIPTION
- bumps the Gradle Docker plugin dependency (along with transitive dependency upgrades, see the [release notes](https://github.com/gesellix/gradle-docker-plugin/releases/tag/v2022-04-23T15-43-00))
- ensures a valid default image name, otherwise tasks might fail (Docker accepts only lowercase image names)
