### PR TITLE
Für Forks extra Workflow zum sicheren publishen der Testresults

### DIFF
--- a/.github/workflows/ci-tests-check.yml
+++ b/.github/workflows/ci-tests-check.yml
@@ -1,0 +1,46 @@
+name: Publish Check CI results
+
+# WARNING:
+# workflow_run provides read-write repo token and access to secrets.
+# Do *not* merge changes to this file without the proper review.
+# We should only be running trusted code here.
+on:
+  workflow_run:
+    workflows: ["Test Result CI"]
+    types:
+      - completed
+
+jobs:
+  # Job based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  publish-check-ci:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # Unfortunately, the official actions/download-artifact action is very limited in scope.
+      # Can't use it yet in this context, https://github.com/actions/download-artifact/issues/60
+      - name: Download artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "check-ci-results"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/check-ci-results.zip', Buffer.from(download.data));
+      - run: unzip check-ci-results.zip
+      - name: Publish Test Results
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
   ci:
@@ -27,9 +27,10 @@ jobs:
           cache: 'gradle'
       - name: clean build
         run: ./gradlew clean build --no-daemon --info --stacktrace
-      - name: Publish Test Report
+      - name: Upload Test Results
+        # see ci-test.check.yml for workflow that publishes test results without security issues for forks
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          name: check-ci-results
+          path: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
siehe Kommentar [hier](https://github.com/europace/docker-publish-gradle-plugin/pull/95#issuecomment-1110041493)

und Erklärung [hier](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)