### PR TITLE
Enable Gradle 8 compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,6 @@ val kotlinxVersion = "1.6.4"
 val mockkVersion = "1.13.4"
 
 plugins {
-  `maven-publish`
-  `java-gradle-plugin`
   kotlin("jvm") version "1.8.10" // remember to update in dependency
   id("com.gradle.plugin-publish") version "1.1.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,19 +76,16 @@ allprojects {
   }
 }
 
-pluginBundle {
-  website = "https://github.com/europace/docker-publish-gradle-plugin"
-  vcsUrl = "https://github.com/europace/docker-publish-gradle-plugin"
-  tags = listOf("docker", "publish", "publishing")
-}
-
 gradlePlugin {
+  website.set("https://github.com/europace/docker-publish-gradle-plugin")
+  vcsUrl.set("https://github.com/europace/docker-publish-gradle-plugin")
   plugins {
     create("dockerPublishPlugin") {
       id = "de.europace.docker-publish"
       displayName = "Docker Publish Plugin"
       description = "Adds tasks to create and publish a Docker image to a registry"
       implementationClass = "de.europace.gradle.docker.publish.DockerPublishPlugin"
+      tags.set(listOf("docker", "publish", "publishing"))
     }
   }
 }


### PR DESCRIPTION
Currently our action to upgradle gradle is failing because of incompatibilities. After reading [the documentation](https://plugins.gradle.org/docs/publish-plugin#examples) I can see that the pluginBundles part is merged into the gradlePlugin part.

So I adapted it to enable the action to work again