### PR TITLE
Use version-catalogs to handle dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,7 @@
 val javaVersion = JavaVersion.VERSION_1_8
-val junitVersion = "5.9.1"
-val kotestVersion = "5.6.2"
-val kotlinVersion = "1.8.22" // remember to update in plugins
-val kotlinxVersion = "1.6.4"
-val mockkVersion = "1.13.7"
 
 plugins {
-  kotlin("jvm") version "1.8.22" // remember to update in dependency
+  alias(libs.plugins.kotlinJvm)
   id("com.gradle.plugin-publish") version "1.2.0"
 }
 
@@ -14,18 +9,15 @@ group = "de.europace.gradle"
 logger.lifecycle("version: $version")
 
 val dependencyVersions = listOf(
-    "com.squareup.okio:okio:3.5.0",
-    "io.mockk:mockk:$mockkVersion"
+    libs.annotations,
+    libs.mockk,
+    libs.okio
 )
 
 val dependencyVersionsByGroup = mapOf(
-    "net.bytebuddy" to "1.12.10",
-    "org.jetbrains.kotlin" to kotlinVersion,
-    "org.jetbrains.kotlinx" to kotlinxVersion,
-    "org.junit" to junitVersion,
-    "org.junit.jupiter" to junitVersion,
-    "org.junit.platform" to "1.9.1",
-    "org.slf4j" to "1.7.36"
+    "net.bytebuddy" to libs.versions.byteBuddy.get(),
+    "org.jetbrains.kotlin" to libs.versions.kotlin.get(),
+    "org.jetbrains.kotlinx" to libs.versions.kotlinx.get()
 )
 
 java {
@@ -51,13 +43,10 @@ repositories {
 
 dependencies {
   implementation(gradleApi())
-  implementation("de.gesellix:gradle-docker-plugin:2023-08-16T09-45-00")
+  implementation(libs.gradleDocker)
 
-  testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
-  testImplementation("io.kotest:kotest-framework-engine-jvm:$kotestVersion")
-  testImplementation("io.kotest:kotest-property-jvm:$kotestVersion")
-  testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
-  testImplementation("io.mockk:mockk:$mockkVersion")
+  testImplementation(libs.bundles.kotest)
+  testImplementation(libs.mockk)
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,28 @@
+[versions]
+byteBuddy = "1.12.20"
+junit = "5.9.1"
+kotest = "5.6.2"
+kotlin = "1.9.0"
+kotlinx = "1.6.4"
+mockk = "1.13.7"
+
+
+[libraries]
+gradleDocker = { module = "de.gesellix:gradle-docker-plugin", version = "2023-08-16T09-45-00" }
+kotest = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
+kotestEngine = { module = "io.kotest:kotest-framework-engine-jvm", version.ref = "kotest" }
+kotestProperty = { module = "io.kotest:kotest-property-jvm", version.ref = "kotest" }
+kotestRunner = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "kotest" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+# for dependency enforcement
+annotations = { module = "org.jetbrains:annotations", version = "23.0.0" }
+byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
+kotlinx = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx" }
+okio = { module = "com.squareup.okio:okio", version = "3.5.0" }
+
+[bundles]
+kotest = ["kotest", "kotestEngine", "kotestProperty", "kotestRunner"]
+
+[plugins]
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
Ich habe hier mal auf version-catalogs umgestellt, damit wir generell so viele Versionen wie möglich aktuell halten können