### PR TITLE
Add URL to pom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,4 +78,13 @@ gradlePlugin {
       tags.set(listOf("docker", "publish", "publishing"))
     }
   }
+  publishing {
+    publications {
+      register("pluginMaven", MavenPublication::class) {
+        pom {
+          url.set("https://github.com/europace/docker-publish-gradle-plugin")
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
My aim is to add the release notes to the dependabot updates.

GitHub Support mentions that the url needs to be set int he pom file