### PR TITLE
Add URL to scm section of pom file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,9 @@ gradlePlugin {
     publications.withType(MavenPublication::class).configureEach {
       pom {
         url.set("https://github.com/europace/docker-publish-gradle-plugin")
+        scm {
+          url.set("https://github.com/europace/docker-publish-gradle-plugin")
+        }
       }
     }
   }


### PR DESCRIPTION
Other dependencies where it works have the URL in the `scm` context, so another try 😅 