### PR TITLE
remove bouncycastle enforcement, not necessary anymore

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,6 @@ val dependencyGroupVersions = mapOf(
     "net.bytebuddy" to libs.versions.byteBuddy.get(),
     "net.java.dev.jna" to libs.netJavaDev.get().version,
     "org.apache.groovy" to libs.groovy.get().version,
-    "org.bouncycastle" to libs.bouncycastle.get().version,
     "org.jetbrains.kotlin" to libs.versions.kotlin.get(),
     "org.jetbrains.kotlinx" to libs.versions.kotlinx.get(),
     "org.junit.jupiter" to libs.versions.junit.get(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 # for dependency enforcement
 annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
-bouncycastle = { module = "org.bouncycastle:bcpkix-jdk18on", version = "1.84" }
 byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
 groovy = { module = "org.codehaus.groovy:groovy", version = "4.0.29" }
 kotlinxBom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx" }


### PR DESCRIPTION
Das docker-gradle-plugin wurde aktualisiert und enthält jetzt die aktuelle Bouncycastle Version, dementsprechend kann das Enforcement hier (und dann auch in allen Services, sobald sie diese Version nutzen) wieder raus.